### PR TITLE
set "main" field in package.json to allow `import 'ng-on';` more seamlessly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-on",
   "version": "0.0.5",
   "description": "Directive for Angular 1.x to easily bind custom (or not) events",
-  "main": "index.js",
+  "main": "src/ng-on.js",
   "scripts": {
     "test": "karma start"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-on",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Directive for Angular 1.x to easily bind custom (or not) events",
   "main": "src/ng-on.js",
   "scripts": {


### PR DESCRIPTION
Now I have to do `import 'ng-on/src/ng-on.js` which is not as nice. :)

I bumped the version as well to convenience you.